### PR TITLE
Correção no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,12 @@ Crie uma página para gerenciar a carteira de gastos em diversas moedas, e que t
                 "ask": "5.6208",
                 ...
               },
+              "USDT": {
+                "code": "USDT",
+                "name": "Dólar Turismo",
+                "ask": "5.7208",
+                ...
+              },
               "CAD": {
                 "code": "CAD",
                 "name": "Dólar Canadense",


### PR DESCRIPTION
Adicionando a moeda USDT no demonstrativo do requisito 8.
Alguns alunos questionaram que o exemplo do estado global não mostrava a moeda USDT, mas o avaliador esperava a presença do mesmo
Solução apresentada: incluir USDT no exemplo do estado.